### PR TITLE
Add desktop Enter key behavior toggle for chat input

### DIFF
--- a/src/components/shared/ChatInput.tsx
+++ b/src/components/shared/ChatInput.tsx
@@ -71,10 +71,14 @@ export const ChatInput = memo(function ChatInput({
 }: ChatInputProps) {
   const { t } = useTranslation();
   const getModelById = useProviderStore((s) => s.getModelById);
+  const enterToSend = useSettingsStore((s) => s.settings.enterToSend);
   const basePlaceholder = placeholder ?? t("chat.message");
+  const isMac = navigator.platform.toLowerCase().includes("mac");
+  const sendKey = enterToSend ? "Enter" : isMac ? "⌘Enter" : "Ctrl+Enter";
+  const newLineKey = enterToSend ? "Shift+Enter" : "Enter";
   const resolvedPlaceholder = isMobile
     ? basePlaceholder
-    : `${basePlaceholder}  (Enter · Shift+Enter ${t("chat.newLine")})`;
+    : `${basePlaceholder}  (${sendKey} · ${newLineKey} ${t("chat.newLine")})`;
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [attachedImages, setAttachedImages] = useState<string[]>([]);
@@ -219,9 +223,18 @@ export const ChatInput = memo(function ChatInput({
           return;
         }
       }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        handleSend();
+      if (enterToSend) {
+        // Default mode: Enter sends, Shift+Enter is newline
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          handleSend();
+        }
+      } else {
+        // Newline mode: Cmd/Ctrl+Enter sends, Enter is newline
+        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          handleSend();
+        }
       }
     },
     [
@@ -232,6 +245,7 @@ export const ChatInput = memo(function ChatInput({
       participantEntries,
       mentionIndex,
       insertMention,
+      enterToSend,
     ],
   );
 

--- a/src/components/shared/ChatInput.tsx
+++ b/src/components/shared/ChatInput.tsx
@@ -28,6 +28,8 @@ import {
   type ParsedFile,
 } from "../../lib/file-parser";
 
+const isMac = navigator.userAgent.toLowerCase().includes("mac");
+
 // ── ChatInput — 1:1 port of RN src/components/chat/ChatInput.tsx ──
 
 interface ChatInputProps {
@@ -73,12 +75,13 @@ export const ChatInput = memo(function ChatInput({
   const getModelById = useProviderStore((s) => s.getModelById);
   const enterToSend = useSettingsStore((s) => s.settings.enterToSend);
   const basePlaceholder = placeholder ?? t("chat.message");
-  const isMac = navigator.platform.toLowerCase().includes("mac");
-  const sendKey = enterToSend ? "Enter" : isMac ? "⌘Enter" : "Ctrl+Enter";
-  const newLineKey = enterToSend ? "Shift+Enter" : "Enter";
   const resolvedPlaceholder = isMobile
     ? basePlaceholder
-    : `${basePlaceholder}  (${sendKey} · ${newLineKey} ${t("chat.newLine")})`;
+    : (() => {
+        const sendKey = enterToSend ? "Enter" : isMac ? "⌘Enter" : "Ctrl+Enter";
+        const newLineKey = enterToSend ? "Shift+Enter" : "Enter";
+        return `${basePlaceholder}  (${sendKey} · ${newLineKey} ${t("chat.newLine")})`;
+      })();
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [attachedImages, setAttachedImages] = useState<string[]>([]);
@@ -224,13 +227,11 @@ export const ChatInput = memo(function ChatInput({
         }
       }
       if (enterToSend) {
-        // Default mode: Enter sends, Shift+Enter is newline
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           handleSend();
         }
       } else {
-        // Newline mode: Cmd/Ctrl+Enter sends, Enter is newline
         if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
           e.preventDefault();
           handleSend();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -233,6 +233,7 @@
     "appearance": "Appearance",
     "chat": "Chat",
     "contextCompression": "Context Compression",
+    "enterToSend": "Enter to Send",
     "compressionThreshold": "Threshold",
     "workspaceDir": "Workspace Directory",
     "selectDir": "Select",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -235,6 +235,7 @@
     "appearance": "外观",
     "chat": "对话",
     "contextCompression": "上下文压缩",
+    "enterToSend": "Enter 键发送",
     "compressionThreshold": "触发阈值",
     "workspaceDir": "工作目录",
     "selectDir": "选择",

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../icons";
 import {
   ArrowLeftRight,
+  ArrowUp,
   Wrench,
   Mic,
   Minimize2,
@@ -306,6 +307,41 @@ export function SettingsPage({
               />
             </div>
           </div>
+          {/* Enter key behavior — desktop only */}
+          {window.innerWidth >= 768 && (
+            <div
+              className="flex w-full items-center gap-4 px-4 py-3"
+              style={{ borderTop: "0.5px solid var(--border)" }}
+            >
+              <div
+                className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full"
+                style={{ backgroundColor: "rgba(99,102,241,0.1)" }}
+              >
+                <ArrowUp size={18} color="#6366f1" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <span className="text-foreground text-[16px] font-medium">
+                  {t("settings.enterToSend")}
+                </span>
+              </div>
+              <div
+                onClick={() => updateSettings({ enterToSend: !settings.enterToSend })}
+                className="relative inline-flex h-7 w-12 flex-shrink-0 cursor-pointer rounded-full transition-colors"
+                style={{
+                  backgroundColor: settings.enterToSend ? "var(--primary)" : "var(--muted)",
+                }}
+              >
+                <span
+                  className="inline-block h-6 w-6 transform rounded-full bg-white shadow transition-transform"
+                  style={{
+                    transform: settings.enterToSend
+                      ? "translateX(20px) translateY(2px)"
+                      : "translateX(2px) translateY(2px)",
+                  }}
+                />
+              </div>
+            </div>
+          )}
         </div>
 
         {/* ── Group 3: Appearance ── */}

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -17,6 +17,8 @@ export interface AppSettings {
   contextCompressionEnabled: boolean;
   /** Token threshold to trigger compression (default: 8000) */
   contextCompressionThreshold: number;
+  /** Enter key behavior on desktop: true = Enter sends (default), false = Enter inserts newline */
+  enterToSend: boolean;
 }
 
 interface SettingsState {
@@ -35,6 +37,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   sttModel: "whisper-large-v3-turbo",
   contextCompressionEnabled: false,
   contextCompressionThreshold: 16000,
+  enterToSend: true,
 };
 
 const SETTINGS_KEY = "settings";


### PR DESCRIPTION
## Summary

This PR adds a new `enterToSend` setting so desktop users can choose how the chat input handles the `Enter` key.

When enabled, `Enter` sends the message and `Shift+Enter` inserts a new line.  
When disabled, `Enter` inserts a new line and `Cmd/Ctrl+Enter` sends the message.

## Changes

- Add `enterToSend` to app settings with a default value of `true`
- Add localized labels for the new setting in English and Chinese
- Add a toggle for this option in the Settings > Chat section on desktop
- Update `ChatInput` keyboard handling to respect the setting
- Update the desktop placeholder shortcut hint to match the selected behavior
- Refactor the related key handling logic in `ChatInput` for clarity

## Notes

- This change only affects the desktop experience
- Existing behavior remains the default: `Enter` sends, `Shift+Enter` inserts a new line

## Testing

- Verified the new toggle appears in Settings > Chat on desktop
- Verified `Enter` / `Shift+Enter` behavior when `Enter to Send` is enabled
- Verified `Enter` / `Cmd/Ctrl+Enter` behavior when `Enter to Send` is disabled
- Verified the placeholder shortcut hint updates accordingly

## Screenshots
<img width="1212" height="812" alt="Screenshot 2026-04-02 at 22 55 17" src="https://github.com/user-attachments/assets/d78d660c-03fa-4af8-96e1-8f058aca1795" />